### PR TITLE
Retter opp i cpsvno.ttl - manglende prefix-def

### DIFF
--- a/ontology/cpsvno.ttl
+++ b/ontology/cpsvno.ttl
@@ -1,5 +1,9 @@
 @prefix adms: <http://www.w3.org/ns/adms#> . 
+@prefix cpsv: <http://purl.org/vocab/cpsv#> .
+@prefix cv: <http://data.europa.eu/m8g/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -12,7 +16,7 @@
 ### About this ontology:
 
 <https://data.norge.no/vocabulary/cpsvno#> rdf:type owl:Ontology ;
-   rdfs:label "CPSV-AP-NO"@en , "CPSV-AP-NO"@nb ;
+   rdfs:label "Ontology for CPSV-AP-NO - Norwegian Application Profile of CPSV-AP"@en , "Ontologi for CPSV-AP-NO - Norsk applikasjonsprofil av CPSV-AP"@nb ;
    rdfs:comment "Ontologi for CPSV-AP-NO - Norsk applikasjonsprofil av CPSV-AP."@nb ,
       "Ontology for CPSV-AP-NO - Norwegian Application Profile of CPSV-AP"@en ;
    rdfs:isDefinedBy "Digitaliseringsdirektoratet"@nb , "Norwegian Digitalisation Agency"@en ;

--- a/ontology/index.html
+++ b/ontology/index.html
@@ -2,7 +2,7 @@
 <html lang="nb">
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
-	<title>CPSV-AP-NO</title>
+	<title>Ontologi for CPSV-AP-NO - Norsk applikasjonsprofil av CPSV-AP</title>
 	<meta name="generator" content="LibreOffice 7.3.0.3 (Windows)"/>
 	<meta name="created" content="00:00:00"/>
 	<meta name="changed" content="00:00:00"/>
@@ -15,8 +15,12 @@
 		pre.ctl { font-family: "Liberation Mono", monospace; font-size: 10pt }
 	</style>
 </head>
-<body lang="nb-NO" link="#000080" vlink="#800000" dir="ltr"><pre class="western">@prefix adms: &lt;http://www.w3.org/ns/adms#&gt; .
-@prefix dct: &lt;http://purl.org/dc/terms/&gt; . 
+<body lang="nb-NO" link="#000080" vlink="#800000" dir="ltr"><pre class="western">@prefix adms: &lt;http://www.w3.org/ns/adms#&gt; . 
+@prefix cpsv: &lt;http://purl.org/vocab/cpsv#&gt; .
+@prefix cv: &lt;http://data.europa.eu/m8g/&gt; .
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dct: &lt;http://purl.org/dc/terms/&gt; .
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
 @prefix owl: &lt;http://www.w3.org/2002/07/owl#&gt; .
 @prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
 @prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
@@ -29,7 +33,7 @@
 ### About this ontology:
 
 &lt;https://data.norge.no/vocabulary/cpsvno#&gt; rdf:type owl:Ontology ;
-   rdfs:label &quot;CPSV-AP-NO&quot;@en , &quot;CPSV-AP-NO&quot;@nb ;
+   rdfs:label &quot;Ontology for CPSV-AP-NO - Norwegian Application Profile of CPSV-AP&quot;@en , &quot;Ontologi for CPSV-AP-NO - Norsk applikasjonsprofil av CPSV-AP&quot;@nb ;
    rdfs:comment &quot;Ontologi for CPSV-AP-NO - Norsk applikasjonsprofil av CPSV-AP.&quot;@nb ,
       &quot;Ontology for CPSV-AP-NO - Norwegian Application Profile of CPSV-AP&quot;@en ;
    rdfs:isDefinedBy &quot;Digitaliseringsdirektoratet&quot;@nb , &quot;Norwegian Digitalisation Agency&quot;@en ;


### PR DESCRIPTION
Forsøker igjen med å publisere ontologifilene for cpsvno. 

Nils Ove forklarte at action feilet pga. at det var syntaks-feil i turtle-filen. Håper det hjelper. 