### PR TITLE
Presiserer ekstern lenke i navnerom til schema.org

### DIFF
--- a/docs/Navnerom.adoc
+++ b/docs/Navnerom.adoc
@@ -20,7 +20,7 @@ Navnerom for dette vokabularet er: `\https://data.norge.no/vocabulary/cpsvno#`
 |org | `\http://www.w3.org/ns/org#` | https://www.w3.org/TR/vocab-org/[The Organization Ontology &#x29C9;, window="_blank", role="ext-link"]
 |rdf | `\http://www.w3.org/1999/02/22-rdf-syntax-ns#` | https://www.w3.org/TR/rdf-syntax-grammar/[RDF 1.1 XML Syntax &#x29C9;, window="_blank", role="ext-link"]
 |rdfs | `\http://www.w3.org/2000/01/rdf-schema#` | https://www.w3.org/TR/rdf-schema/[RDF Schema 1.1 &#x29C9;, window="_blank", role="ext-link"]
-| schema | `\https://schema.org/` | https://schema.org/[schema.org]
+| schema | `\https://schema.org/` | https://schema.org/[schema.org &#x29C9;, window="_blank", role="ext-link"]
 |skos | `\http://www.w3.org/2004/02/skos/core#` | https://www.w3.org/TR/skos-reference/[SKOS Simple Knowledge Organization System &#x29C9;, window="_blank", role="ext-link"]
 |time | `\http://www.w3.org/2006/time#` | https://www.w3.org/TR/owl-time/[Time Ontology in OWL &#x29C9;, window="_blank", role="ext-link"]
 |vcard | `\http://www.w3.org/2006/vcard/ns#` | https://www.w3.org/TR/vcard-rdf/[vCard Ontology – for describing People and Organizations &#x29C9;, window="_blank", role="ext-link"]


### PR DESCRIPTION
Glemte i forrige PR å markere ekstern lenke til schema.org, derfor denne strafferunde