### PR TITLE
Oppdaterer workflow for ontology

### DIFF
--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -23,13 +23,13 @@ jobs:
         id: adocbuild_html_en
         uses: tonynv/asciidoctor-action@master
         with:
-          program: "asciidoctor -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
+          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
 
       - name: Build html nb
         id: adocbuild_html_nb
         uses: tonynv/asciidoctor-action@master
         with:
-          program: "asciidoctor -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
+          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
   
       - name: Upload files to server
         uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0

--- a/ontology/main-en.adoc
+++ b/ontology/main-en.adoc
@@ -16,7 +16,7 @@ image::../docs/images/Digdir.png[alt="Digdir-logo", width=30%, pdfwidth=30vw, li
 
 NOTE: The following is an HTML-view of the ontology `cpsvno` expressed in RDF Turtle, which defines classes and properties specified in https://data.norge.no/specification/cpsv-ap-no[CPSV-AP-NO &#x29C9;, window="_blank", role="ext-link"]. +
  +
-Please use https://github.com/Informasjonsforvaltning/cpsv-ap-no/issues[Github Issues] to give us your feedback, if any.
+Please use https://github.com/Informasjonsforvaltning/cpsv-ap-no/issues[Github Issues &#x29C9;, window="_blank", role="ext-link"] to give us your feedback, if any.
 
 -----
 include::cpsvno.ttl[]


### PR DESCRIPTION
Digdir-logoen ble ikke tatt med i html-genereringen av ontologi-filen (data.norge.no/vocabulary/cpsvno). Trenger derfor å oppdatere workflowen for å få med logoen. 