### PR TITLE
chore: pin Analog-inc/asciidoctor-action to commit SHA

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -30,13 +30,13 @@ jobs:
 
     - name: Build html
       id: adocbuild
-      uses: Analog-inc/asciidoctor-action@master
+      uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
       with:
           shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
     - name: Build pdf
       id: adocbuild_pdf
-      uses: Analog-inc/asciidoctor-action@master
+      uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
       with:
           shellcommand: "asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc"
       continue-on-error: true

--- a/.github/workflows/adocs-build-v1-production.yml
+++ b/.github/workflows/adocs-build-v1-production.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Build html
         id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
         with:
           shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
         with:
           shellcommand: "asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Build html en
         id: adocbuild_html_en
-        uses: Analog-inc/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
         with:
           shellcommand: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
 
       - name: Build html nb
         id: adocbuild_html_nb
-        uses: Analog-inc/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
         with:
           shellcommand: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
   


### PR DESCRIPTION
# Summary

- Pin `Analog-inc/asciidoctor-action@master` to immutable commit SHA `328aa83f` across all 3 build workflows (6 occurrences)
- Original ref preserved as inline comment (`# master`) for readability
- No behavioral change — same action code, just immutably pinned