### PR TITLE
chore: use reusable adoc workflows

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -2,7 +2,6 @@ name: build adocs
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -12,37 +11,16 @@ on:
     - docs/**
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      with:
-        submodules: true
-        fetch-depth: 0
-
-    - name: Update submodules to latest main
-      run: |
-        git submodule foreach --recursive git fetch origin
-        git submodule foreach --recursive git checkout origin/main
-
-    - name: Build html
-      id: adocbuild
-      uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-      with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-    - name: Build pdf
-      id: adocbuild_pdf
-      uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-      with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc"
-      continue-on-error: true
-
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+  build-adocs:
+    name: Build and deploy editor's draft to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-v1-production.yml
+++ b/.github/workflows/adocs-build-v1-production.yml
@@ -12,89 +12,66 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "specification"
-          ontology: "cpsv-ap-no"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/cpsv-ap-no.pdf application/pdf nb files/cpsv-ap-no.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/CPSV-AP-NO-forenklet-fremstilling.png image/png nb images/CPSV-AP-NO-forenklet-fremstilling.png
-            docs/images/CPSV-AP-NO-klasser.png image/png nb images/CPSV-AP-NO-klasser.png
-            docs/images/FigurEksempelDokumentasjonskrav.png image/png nb images/FigurEksempelDokumentasjonskrav.png
-            docs/images/FigurEksempelDokumentasjonskrav2.png image/png nb images/FigurEksempelDokumentasjonskrav2.png
-            docs/images/FigurHendelseOgDistribusjon.png image/png nb images/FigurHendelseOgDistribusjon.png
-            docs/images/FigurHendelseTjenesteData.png image/png nb images/FigurHendelseTjenesteData.png
-            docs/images/FigurKatalog.png image/png nb images/FigurKatalog.png
-            docs/images/FigurSyktBarn.png image/png nb images/FigurSyktBarn.png
-            docs/images/FigurSyktBarnBeskrevetMedCPSVNO.png image/png nb images/FigurSyktBarnBeskrevetMedCPSVNO.png
-            docs/images/FigurTjenestekjede.png image/png nb images/FigurTjenestekjede.png
-            docs/images/FigurTjenesteMedDataInnOgUt.png image/png nb images/FigurTjenesteMedDataInnOgUt.png
-            docs/images/FigurTjenesteOgDeltagelse.png image/png nb images/FigurTjenesteOgDeltagelse.png
-            docs/images/FigurTjenesteOgRegelverk.png image/png nb images/FigurTjenesteOgRegelverk.png
-            docs/images/KlassenAdresse.png image/png nb images/KlassenAdresse.png
-            docs/images/KlassenAktør.png image/png nb images/KlassenAktør.png
-            docs/images/KlassenBegrensning.png image/png nb images/KlassenBegrensning.png
-            docs/images/KlassenDeltagelse.png image/png nb images/KlassenDeltagelse.png
-            docs/images/KlassenDokumentasjonstype.png image/png nb images/KlassenDokumentasjonstype.png
-            docs/images/KlassenDokumentasjonstypeliste.png image/png nb images/KlassenDokumentasjonstypeliste.png
-            docs/images/KlassenGebyr.png image/png nb images/KlassenGebyr.png
-            docs/images/KlassenHendelse.png image/png nb images/KlassenHendelse.png
-            docs/images/KlassenInformasjonsbegrep.png image/png nb images/KlassenInformasjonsbegrep.png
-            docs/images/KlassenInformasjonskrav.png image/png nb images/KlassenInformasjonskrav.png
-            docs/images/KlassenKatalog.png image/png nb images/KlassenKatalog.png
-            docs/images/KlassenKontaktpunkt.png image/png nb images/KlassenKontaktpunkt.png
-            docs/images/KlassenKrav.png image/png nb images/KlassenKrav.png
-            docs/images/KlassenKriterium.png image/png nb images/KlassenKriterium.png
-            docs/images/KlassenLivshendelse.png image/png nb images/KlassenLivshendelse.png
-            docs/images/KlassenMuligTjenesteresultat.png image/png nb images/KlassenMuligTjenesteresultat.png
-            docs/images/KlassenOffentligOrganisasjon.png image/png nb images/KlassenOffentligOrganisasjon.png
-            docs/images/KlassenOffentligTjeneste.png image/png nb images/KlassenOffentligTjeneste.png
-            docs/images/KlassenOrganisasjon.png image/png nb images/KlassenOrganisasjon.png
-            docs/images/KlassenPåkrevdDokumentasjon.png image/png nb images/KlassenPåkrevdDokumentasjon.png
-            docs/images/KlassenReferanserammeverk.png image/png nb images/KlassenReferanserammeverk.png
-            docs/images/KlassenRegel.png image/png nb images/KlassenRegel.png
-            docs/images/KlassenRegulativRessurs.png image/png nb images/KlassenRegulativRessurs.png
-            docs/images/KlassenTidsenhet.png image/png nb images/KlassenTidsenhet.png
-            docs/images/KlassenTidspunkt.png image/png nb images/KlassenTidspunkt.png
-            docs/images/KlassenTidspunktbeskrivelse.png image/png nb images/KlassenTidspunktbeskrivelse.png
-            docs/images/KlassenTidsrom.png image/png nb images/KlassenTidsrom.png
-            docs/images/KlassenTjeneste.png image/png nb images/KlassenTjeneste.png
-            docs/images/KlassenTjenestekanal.png image/png nb images/KlassenTjenestekanal.png
-            docs/images/KlassenTjenestekonsesjonskontrakt.png image/png nb images/KlassenTjenestekonsesjonskontrakt.png
-            docs/images/KlassenVirksomhetshendelse.png image/png nb images/KlassenVirksomhetshendelse.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/cpsv-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      host: https://data.norge.no
+      ontology: cpsv-ap-no
+      ontology-type: specification
+      files: |
+        docs/index.html text/html nb
+        docs/files/cpsv-ap-no.pdf application/pdf nb files/cpsv-ap-no.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/CPSV-AP-NO-forenklet-fremstilling.png image/png nb images/CPSV-AP-NO-forenklet-fremstilling.png
+        docs/images/CPSV-AP-NO-klasser.png image/png nb images/CPSV-AP-NO-klasser.png
+        docs/images/FigurEksempelDokumentasjonskrav.png image/png nb images/FigurEksempelDokumentasjonskrav.png
+        docs/images/FigurEksempelDokumentasjonskrav2.png image/png nb images/FigurEksempelDokumentasjonskrav2.png
+        docs/images/FigurHendelseOgDistribusjon.png image/png nb images/FigurHendelseOgDistribusjon.png
+        docs/images/FigurHendelseTjenesteData.png image/png nb images/FigurHendelseTjenesteData.png
+        docs/images/FigurKatalog.png image/png nb images/FigurKatalog.png
+        docs/images/FigurSyktBarn.png image/png nb images/FigurSyktBarn.png
+        docs/images/FigurSyktBarnBeskrevetMedCPSVNO.png image/png nb images/FigurSyktBarnBeskrevetMedCPSVNO.png
+        docs/images/FigurTjenestekjede.png image/png nb images/FigurTjenestekjede.png
+        docs/images/FigurTjenesteMedDataInnOgUt.png image/png nb images/FigurTjenesteMedDataInnOgUt.png
+        docs/images/FigurTjenesteOgDeltagelse.png image/png nb images/FigurTjenesteOgDeltagelse.png
+        docs/images/FigurTjenesteOgRegelverk.png image/png nb images/FigurTjenesteOgRegelverk.png
+        docs/images/KlassenAdresse.png image/png nb images/KlassenAdresse.png
+        docs/images/KlassenAktør.png image/png nb images/KlassenAktør.png
+        docs/images/KlassenBegrensning.png image/png nb images/KlassenBegrensning.png
+        docs/images/KlassenDeltagelse.png image/png nb images/KlassenDeltagelse.png
+        docs/images/KlassenDokumentasjonstype.png image/png nb images/KlassenDokumentasjonstype.png
+        docs/images/KlassenDokumentasjonstypeliste.png image/png nb images/KlassenDokumentasjonstypeliste.png
+        docs/images/KlassenGebyr.png image/png nb images/KlassenGebyr.png
+        docs/images/KlassenHendelse.png image/png nb images/KlassenHendelse.png
+        docs/images/KlassenInformasjonsbegrep.png image/png nb images/KlassenInformasjonsbegrep.png
+        docs/images/KlassenInformasjonskrav.png image/png nb images/KlassenInformasjonskrav.png
+        docs/images/KlassenKatalog.png image/png nb images/KlassenKatalog.png
+        docs/images/KlassenKontaktpunkt.png image/png nb images/KlassenKontaktpunkt.png
+        docs/images/KlassenKrav.png image/png nb images/KlassenKrav.png
+        docs/images/KlassenKriterium.png image/png nb images/KlassenKriterium.png
+        docs/images/KlassenLivshendelse.png image/png nb images/KlassenLivshendelse.png
+        docs/images/KlassenMuligTjenesteresultat.png image/png nb images/KlassenMuligTjenesteresultat.png
+        docs/images/KlassenOffentligOrganisasjon.png image/png nb images/KlassenOffentligOrganisasjon.png
+        docs/images/KlassenOffentligTjeneste.png image/png nb images/KlassenOffentligTjeneste.png
+        docs/images/KlassenOrganisasjon.png image/png nb images/KlassenOrganisasjon.png
+        docs/images/KlassenPåkrevdDokumentasjon.png image/png nb images/KlassenPåkrevdDokumentasjon.png
+        docs/images/KlassenReferanserammeverk.png image/png nb images/KlassenReferanserammeverk.png
+        docs/images/KlassenRegel.png image/png nb images/KlassenRegel.png
+        docs/images/KlassenRegulativRessurs.png image/png nb images/KlassenRegulativRessurs.png
+        docs/images/KlassenTidsenhet.png image/png nb images/KlassenTidsenhet.png
+        docs/images/KlassenTidspunkt.png image/png nb images/KlassenTidspunkt.png
+        docs/images/KlassenTidspunktbeskrivelse.png image/png nb images/KlassenTidspunktbeskrivelse.png
+        docs/images/KlassenTidsrom.png image/png nb images/KlassenTidsrom.png
+        docs/images/KlassenTjeneste.png image/png nb images/KlassenTjeneste.png
+        docs/images/KlassenTjenestekanal.png image/png nb images/KlassenTjenestekanal.png
+        docs/images/KlassenTjenestekonsesjonskontrakt.png image/png nb images/KlassenTjenestekonsesjonskontrakt.png
+        docs/images/KlassenVirksomhetshendelse.png image/png nb images/KlassenVirksomhetshendelse.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -12,44 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build_and_upload:
-    name: Adoc-build html and Upload vocabulary to server
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: Analog-inc/asciidoctor-action@328aa83fd20efb2e8899a34716db60c9ddf2d9a0  # master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-  
-      - name: Upload files to server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "vocabulary"
-          ontology: "cpsvno"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            ontology/cpsvno.ttl text/turtle en
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+  upload-files-to-production:
+    name: Upload vocabulary to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://data.norge.no
+      ontology: cpsvno
+      ontology-type: vocabulary
+      files: |
+        ontology/cpsvno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary 

- Migrate the three asciidoctor build/publish workflows to call the central Informasjonsforvaltning/workflows reusable workflows (specification-github-pages, specification-upload-files)
- Removes all unpinned third-party action references from this repo, resolving #277 — pinning is now handled upstream
- Preserves triggers, file lists, ontology names, and lenient PDF builds via program_pdf_continue_on_error
- Note: production workflows run from the v1 branch, which needs a separate follow-up PR targeting v1